### PR TITLE
Avoid running argparse on import

### DIFF
--- a/src/core/base.py
+++ b/src/core/base.py
@@ -21,13 +21,13 @@ from evaluation import compute_error_verts, compute_similarity_transform, comput
                     batch_compute_similarity_transform_torch, compute_mpjpe
 from dataset.mixed_dataset import SingleDataset
 from visualization.visualization import Visualizer
-if args.model_precision=='fp16':
+if args().model_precision=='fp16':
     from torch.cuda.amp import autocast, GradScaler
 
 class Base(object):
     def __init__(self):
         self.project_dir = config.project_dir
-        hparams_dict = self.load_config_dict(vars(args))
+        hparams_dict = self.load_config_dict(vars(args()))
         self._init_params()
 
     def _build_model_(self):

--- a/src/core/base.py
+++ b/src/core/base.py
@@ -12,7 +12,7 @@ from torch.utils.data import Dataset, DataLoader, ConcatDataset
 import _init_paths
 import config
 import constants
-from config import args
+from config import args, parse_args, ConfigContext
 from models import build_model
 from utils import load_model, get_remove_keys, reorganize_items
 from utils.demo_utils import img_preprocess, convert_cam_to_3d_trans, save_meshes, get_video_bn
@@ -21,8 +21,9 @@ from evaluation import compute_error_verts, compute_similarity_transform, comput
                     batch_compute_similarity_transform_torch, compute_mpjpe
 from dataset.mixed_dataset import SingleDataset
 from visualization.visualization import Visualizer
-if args().model_precision=='fp16':
-    from torch.cuda.amp import autocast, GradScaler
+# GradScaler never used
+# if args().model_precision=='fp16':
+#     from torch.cuda.amp import autocast, GradScaler
 
 class Base(object):
     def __init__(self):
@@ -74,6 +75,7 @@ class Base(object):
         ds_org, imgpath_org = get_remove_keys(meta_data,keys=['data_set','imgpath'])
         meta_data['batch_ids'] = torch.arange(len(meta_data['image']))
         if self.model_precision=='fp16':
+            from torch.cuda.amp import autocast
             with autocast():
                 outputs = self.model(meta_data, **cfg)
         else:

--- a/src/core/test.py
+++ b/src/core/test.py
@@ -211,6 +211,8 @@ class Time_counter():
         self.frame_num = 0
 
 def main():
+    args = parse_args()
+
     demo = Demo()
     if args.webcam:
         print('Running the code on webcam demo')

--- a/src/core/test.py
+++ b/src/core/test.py
@@ -10,12 +10,12 @@ class Demo(Base):
         self.model.eval()
         self.demo_dir = os.path.join(config.project_dir, 'demo')
         self.vis_size = [1024,1024,3]#[1920,1080]
-        if not args.webcam and '-1' not in self.gpu:
+        if not args().webcam and '-1' not in self.gpu:
             self.visualizer = Visualizer(resolution=self.vis_size, input_size=self.input_size,with_renderer=True)
         else:
             self.save_visualization_on_img = False
         if self.save_mesh:
-            self.smpl_faces = pickle.load(open(os.path.join(args.smpl_model_path,'smpl','SMPL_NEUTRAL.pkl'),'rb'), encoding='latin1')['f']
+            self.smpl_faces = pickle.load(open(os.path.join(args().smpl_model_path,'smpl','SMPL_NEUTRAL.pkl'),'rb'), encoding='latin1')['f']
         print('Initialization finished!')
 
     def run(self, image_folder):
@@ -82,7 +82,7 @@ class Demo(Base):
         return results
 
     def single_image_forward(self,image):
-        meta_data = img_preprocess(image, '0', input_size=args.input_size, single_img_input=True)
+        meta_data = img_preprocess(image, '0', input_size=args().input_size, single_img_input=True)
         if '-1' not in self.gpu:
             meta_data['image'] = meta_data['image'].cuda()
         outputs = self.net_forward(meta_data, cfg=self.demo_cfg)
@@ -123,7 +123,7 @@ class Demo(Base):
         if self.save_video_results:
             video_save_name = os.path.join(self.output_dir, video_basename+'_results.mp4')
             print('Writing results to {}'.format(video_save_name))
-            frames2video(result_frames, video_save_name, fps=args.fps_save)
+            frames2video(result_frames, video_save_name, fps=args().fps_save)
             
     def webcam_run_local(self, video_file_path=None):
         '''
@@ -132,7 +132,7 @@ class Demo(Base):
         print('run on local')
         import keyboard
         from utils.demo_utils import OpenCVCapture, Image_Reader 
-        if 'tex' in args.webcam_mesh_color:
+        if 'tex' in args().webcam_mesh_color:
             from utils.demo_utils import vedo_visualizer as Visualizer
         else:
             from utils.demo_utils import Open3d_visualizer as Visualizer
@@ -157,7 +157,7 @@ class Demo(Base):
             counter.fps()
 
             if outputs is not None and outputs['detection_flag']:
-                if args.show_single:
+                if args().show_single:
                     verts = outputs['verts'].cpu().numpy()
                     verts = verts * 50 + np.array([0, 0, 100])
                     break_flag = visualizer.run(verts[0],frame)
@@ -211,26 +211,23 @@ class Time_counter():
         self.frame_num = 0
 
 def main():
-    args = parse_args()
-
-    demo = Demo()
-    if args.webcam:
-        print('Running the code on webcam demo')
-        if args.run_on_remote_server:
-            demo.webcam_run_remote()
+    with ConfigContext(parse_args()):
+        demo = Demo()
+        if args().webcam:
+            print('Running the code on webcam demo')
+            if args().run_on_remote_server:
+                demo.webcam_run_remote()
+            else:
+                demo.webcam_run_local()
+        elif args().video_or_frame:
+            print('Running the code on video ',args().input_video_path)
+            demo.process_video(args().input_video_path)
         else:
-            demo.webcam_run_local()
-    elif args.video_or_frame:
-        print('Running the code on video ',args.input_video_path)
-        demo.process_video(args.input_video_path)
-    else:
-        demo_image_folder = args.demo_image_folder
-        if not os.path.exists(demo_image_folder):
-            print('Running the code on the demo images')
-            demo_image_folder = os.path.join(demo.demo_dir,'images')
-        demo.run(demo_image_folder)
-
+            demo_image_folder = args().demo_image_folder
+            if not os.path.exists(demo_image_folder):
+                print('Running the code on the demo images')
+                demo_image_folder = os.path.join(demo.demo_dir,'images')
+            demo.run(demo_image_folder)
 
 if __name__ == '__main__':
-
     main()

--- a/src/lib/config.py
+++ b/src/lib/config.py
@@ -5,97 +5,100 @@ import numpy as np
 import torch
 import yaml
 import logging
- 
-code_dir = os.path.abspath(__file__).replace('config.py','')
-project_dir = os.path.abspath(__file__).replace('/src/lib/config.py','')
-root_dir = project_dir.replace(project_dir.split('/')[-1],'')#os.path.abspath(__file__).replace('/CenterMesh/src/config.py','')
-model_dir = os.path.join(project_dir,'models')
-trained_model_dir = os.path.join(project_dir,'trained_models')
 
-parser = argparse.ArgumentParser(description = 'ROMP: Monocular, One-stage, Regression of Multiple 3D People')
-parser.add_argument('--tab',type = str,default = 'ROMP_v1',help = 'additional tabs')
-parser.add_argument('--configs_yml',type = str,default = 'configs/single_image.yml',help = 'setting for training') #'configs/basic_training_v6_ld.yml' 
-parser.add_argument('--demo_image_folder',type = str,default = 'None',help = 'absolute path to the image folder containing the input images for evaluation')
+def parse_args(input_args=None):
+    code_dir = os.path.abspath(__file__).replace('config.py','')
+    project_dir = os.path.abspath(__file__).replace('/src/lib/config.py','')
+    root_dir = project_dir.replace(project_dir.split('/')[-1],'')#os.path.abspath(__file__).replace('/CenterMesh/src/config.py','')
+    model_dir = os.path.join(project_dir,'models')
+    trained_model_dir = os.path.join(project_dir,'trained_models')
 
-mode_group = parser.add_argument_group(title='mode options')
-#mode setting
-mode_group.add_argument('--local_rank',type = int,default=0,help = 'local rank for distributed training')
-mode_group.add_argument('--model_version',type = int,default = 1,help = 'model version')
-mode_group.add_argument('--multi_person',type = bool,default = True,help = 'whether to make Multi-person Recovery')
+    parser = argparse.ArgumentParser(description = 'ROMP: Monocular, One-stage, Regression of Multiple 3D People')
+    parser.add_argument('--tab',type = str,default = 'ROMP_v1',help = 'additional tabs')
+    parser.add_argument('--configs_yml',type = str,default = 'configs/single_image.yml',help = 'setting for training') #'configs/basic_training_v6_ld.yml' 
+    parser.add_argument('--demo_image_folder',type = str,default = 'None',help = 'absolute path to the image folder containing the input images for evaluation')
 
-mode_group.add_argument('--collision_aware_centermap',type = bool,default = False,help = 'whether to use collision_aware_centermap')
-mode_group.add_argument('--collision_factor',type = float,default = 0.2,help = 'whether to use collision_aware_centermap')
-mode_group.add_argument('--kp3d_format', type=str, default='smpl24', help='the joint defination of KP 3D joints: smpl24 or coco25')
-mode_group.add_argument('--eval',type = bool,default = False,help = 'whether to evaluation')
-mode_group.add_argument('--max_person',default=64,type=int,help = 'max person number')
-mode_group.add_argument('--input_size',default=512,type=int,help = 'size of input image')
-mode_group.add_argument('--Rot_type', type=str, default='6D', help='rotation representation type: angular, 6D')
-mode_group.add_argument('--rot_dim', type=int, default=6, help='rotation representation type: 3D angular, 6D')
-mode_group.add_argument('--centermap_conf_thresh',type = float,default = 0.25,help = 'whether to use centermap_conf_thresh')
+    mode_group = parser.add_argument_group(title='mode options')
+    #mode setting
+    mode_group.add_argument('--local_rank',type = int,default=0,help = 'local rank for distributed training')
+    mode_group.add_argument('--model_version',type = int,default = 1,help = 'model version')
+    mode_group.add_argument('--multi_person',type = bool,default = True,help = 'whether to make Multi-person Recovery')
 
-model_group = parser.add_argument_group(title='model settings')
-model_group.add_argument('--centermap_size', type=int, default=64, help='the size of center map')
-model_group.add_argument('--deconv_num', type=int, default=0, help='the size of center map')
-model_group.add_argument('--model_precision', type=str, default='fp16', help='the model precision: fp16/fp32')
-#model settings
-model_group.add_argument('--backbone',type = str,default = 'hrnet',help = 'backbone model: resnet50 or hrnet')
-model_group.add_argument('--input-size',default = 512,type = int, help = 'input image size 512 or 256.')
-model_group.add_argument('--gmodel-path',type = str,default = '',help = 'trained model path of generator')
+    mode_group.add_argument('--collision_aware_centermap',type = bool,default = False,help = 'whether to use collision_aware_centermap')
+    mode_group.add_argument('--collision_factor',type = float,default = 0.2,help = 'whether to use collision_aware_centermap')
+    mode_group.add_argument('--kp3d_format', type=str, default='smpl24', help='the joint defination of KP 3D joints: smpl24 or coco25')
+    mode_group.add_argument('--eval',type = bool,default = False,help = 'whether to evaluation')
+    mode_group.add_argument('--max_person',default=64,type=int,help = 'max person number')
+    mode_group.add_argument('--input_size',default=512,type=int,help = 'size of input image')
+    mode_group.add_argument('--Rot_type', type=str, default='6D', help='rotation representation type: angular, 6D')
+    mode_group.add_argument('--rot_dim', type=int, default=6, help='rotation representation type: 3D angular, 6D')
+    mode_group.add_argument('--centermap_conf_thresh',type = float,default = 0.25,help = 'whether to use centermap_conf_thresh')
 
-train_group = parser.add_argument_group(title='training options')
-#basic training setting
-train_group.add_argument('--print-freq', type = int, default = 50, help = 'training epochs')
-train_group.add_argument('--fine_tune',type = bool,default = False,help = 'whether to run online')
-train_group.add_argument('--gpu',default='0',help='gpus',type=str)
-train_group.add_argument('--batch_size',default=64,help='batch_size',type=int)
-train_group.add_argument('--val_batch_size',default=64,help='valiation batch_size',type=int)
-train_group.add_argument('--nw',default=4,help='number of workers',type=int)
+    model_group = parser.add_argument_group(title='model settings')
+    model_group.add_argument('--centermap_size', type=int, default=64, help='the size of center map')
+    model_group.add_argument('--deconv_num', type=int, default=0, help='the size of center map')
+    model_group.add_argument('--model_precision', type=str, default='fp16', help='the model precision: fp16/fp32')
+    #model settings
+    model_group.add_argument('--backbone',type = str,default = 'hrnet',help = 'backbone model: resnet50 or hrnet')
+    model_group.add_argument('--input-size',default = 512,type = int, help = 'input image size 512 or 256.')
+    model_group.add_argument('--gmodel-path',type = str,default = '',help = 'trained model path of generator')
 
-eval_group = parser.add_argument_group(title='evaluation options')
-eval_group.add_argument('--calc_PVE_error',type = bool,default =False)
+    train_group = parser.add_argument_group(title='training options')
+    #basic training setting
+    train_group.add_argument('--print-freq', type = int, default = 50, help = 'training epochs')
+    train_group.add_argument('--fine_tune',type = bool,default = False,help = 'whether to run online')
+    train_group.add_argument('--gpu',default='0',help='gpus',type=str)
+    train_group.add_argument('--batch_size',default=64,help='batch_size',type=int)
+    train_group.add_argument('--val_batch_size',default=64,help='valiation batch_size',type=int)
+    train_group.add_argument('--nw',default=4,help='number of workers',type=int)
 
-dataset_group = parser.add_argument_group(title='datasets options')
-#dataset setting:
-dataset_group.add_argument('--dataset-rootdir',type=str, default=os.path.join(root_dir,'dataset/'), help= 'root dir of all datasets')
-eval_group = parser.add_argument_group(title='evaluation options')
+    eval_group = parser.add_argument_group(title='evaluation options')
+    eval_group.add_argument('--calc_PVE_error',type = bool,default =False)
 
-other_group = parser.add_argument_group(title='other options')
-#visulaization settings
-other_group.add_argument('--high_resolution',type = bool,default = True,help = 'whether to visulize with high resolution 500*500')
+    dataset_group = parser.add_argument_group(title='datasets options')
+    #dataset setting:
+    dataset_group.add_argument('--dataset-rootdir',type=str, default=os.path.join(root_dir,'dataset/'), help= 'root dir of all datasets')
+    eval_group = parser.add_argument_group(title='evaluation options')
 
-#model save path and log file
-other_group.add_argument('--save-best-folder', type = str, default = os.path.join(root_dir,'checkpoints/'), help = 'Path to save models')
-other_group.add_argument('--log-path', type = str, default = os.path.join(root_dir,'log/'), help = 'Path to save log file')
+    other_group = parser.add_argument_group(title='other options')
+    #visulaization settings
+    other_group.add_argument('--high_resolution',type = bool,default = True,help = 'whether to visulize with high resolution 500*500')
 
-smpl_group = parser.add_argument_group(title='SMPL options')
-#smpl info
-smpl_group.add_argument('--total-param-count',type = int,default = 85, help = 'the count of param param')
-smpl_group.add_argument('--smpl-mean-param-path',type = str,default = os.path.join(model_dir,'satistic_data','neutral_smpl_mean_params.h5'),
-    help = 'the path for mean smpl param value')
-smpl_group.add_argument('--smpl-model',type = str,default = os.path.join(model_dir,'statistic_data','neutral_smpl_with_cocoplus_reg.txt'),
-    help = 'smpl model path')
+    #model save path and log file
+    other_group.add_argument('--save-best-folder', type = str, default = os.path.join(root_dir,'checkpoints/'), help = 'Path to save models')
+    other_group.add_argument('--log-path', type = str, default = os.path.join(root_dir,'log/'), help = 'Path to save log file')
 
-smplx_group = parser.add_argument_group(title='SMPL-X options')
-smpl_group.add_argument('--smplx-model',type = bool,default = True, help = 'the count of param param')
-smpl_group.add_argument('--cam_dim',type = int,default = 3, help = 'the dimention of camera param')
-smpl_group.add_argument('--beta_dim',type = int,default = 10, help = 'the dimention of SMPL shape param, beta')
-smpl_group.add_argument('--smpl_joint_num',type = int,default = 22)
-smpl_group.add_argument('--smpl_model_path',type = str,default = os.path.join(model_dir),help = 'smpl model path')
-smpl_group.add_argument('--smpl_uvmap',type = str,default = os.path.join(model_dir, 'smpl', 'uv_table.npy'),help = 'smpl UV Map coordinates for each vertice')
-smpl_group.add_argument('--smpl_female_texture',type = str,default = os.path.join(model_dir, 'smpl', 'SMPL_sampleTex_f.jpg'),help = 'smpl UV texture for the female')
-smpl_group.add_argument('--smpl_male_texture',type = str,default = os.path.join(model_dir, 'smpl', 'SMPL_sampleTex_m.jpg'),help = 'smpl UV texture for the male')
-smpl_group.add_argument('--smpl_J_reg_h37m_path',type = str,default = os.path.join(model_dir, 'smpl', 'J_regressor_h36m.npy'),help = 'SMPL regressor for 17 joints from H36M datasets')
-smpl_group.add_argument('--smpl_J_reg_extra_path',type = str,default = os.path.join(model_dir, 'smpl', 'J_regressor_extra.npy'),help = 'SMPL regressor for 9 extra joints from different datasets')
+    smpl_group = parser.add_argument_group(title='SMPL options')
+    #smpl info
+    smpl_group.add_argument('--total-param-count',type = int,default = 85, help = 'the count of param param')
+    smpl_group.add_argument('--smpl-mean-param-path',type = str,default = os.path.join(model_dir,'satistic_data','neutral_smpl_mean_params.h5'),
+        help = 'the path for mean smpl param value')
+    smpl_group.add_argument('--smpl-model',type = str,default = os.path.join(model_dir,'statistic_data','neutral_smpl_with_cocoplus_reg.txt'),
+        help = 'smpl model path')
 
-args = parser.parse_args()
-args.kernel_sizes = [5]
-with open(args.configs_yml) as file:
-    configs_update = yaml.full_load(file)
-for key, value in configs_update['ARGS'].items():
-    if isinstance(value,str):
-        exec("args.{} = '{}'".format(key, value))
-    else:
-        exec("args.{} = {}".format(key, value))
+    smplx_group = parser.add_argument_group(title='SMPL-X options')
+    smpl_group.add_argument('--smplx-model',type = bool,default = True, help = 'the count of param param')
+    smpl_group.add_argument('--cam_dim',type = int,default = 3, help = 'the dimention of camera param')
+    smpl_group.add_argument('--beta_dim',type = int,default = 10, help = 'the dimention of SMPL shape param, beta')
+    smpl_group.add_argument('--smpl_joint_num',type = int,default = 22)
+    smpl_group.add_argument('--smpl_model_path',type = str,default = os.path.join(model_dir),help = 'smpl model path')
+    smpl_group.add_argument('--smpl_uvmap',type = str,default = os.path.join(model_dir, 'smpl', 'uv_table.npy'),help = 'smpl UV Map coordinates for each vertice')
+    smpl_group.add_argument('--smpl_female_texture',type = str,default = os.path.join(model_dir, 'smpl', 'SMPL_sampleTex_f.jpg'),help = 'smpl UV texture for the female')
+    smpl_group.add_argument('--smpl_male_texture',type = str,default = os.path.join(model_dir, 'smpl', 'SMPL_sampleTex_m.jpg'),help = 'smpl UV texture for the male')
+    smpl_group.add_argument('--smpl_J_reg_h37m_path',type = str,default = os.path.join(model_dir, 'smpl', 'J_regressor_h36m.npy'),help = 'SMPL regressor for 17 joints from H36M datasets')
+    smpl_group.add_argument('--smpl_J_reg_extra_path',type = str,default = os.path.join(model_dir, 'smpl', 'J_regressor_extra.npy'),help = 'SMPL regressor for 9 extra joints from different datasets')
 
-hrnet_pretrain = os.path.join(project_dir,'trained_models/pretrain.pkl') #os.path.join(model_dir,'pretrain_models','pose_higher_hrnet_w32_512.pth') #
-args.tab = '{}_cm{}_{}'.format(args.backbone,args.centermap_size,args.tab)
+    args = parser.parse_args(args=input_args)
+    args.kernel_sizes = [5]
+    with open(args.configs_yml) as file:
+        configs_update = yaml.full_load(file)
+    for key, value in configs_update['ARGS'].items():
+        if isinstance(value,str):
+            exec("args.{} = '{}'".format(key, value))
+        else:
+            exec("args.{} = {}".format(key, value))
+
+    hrnet_pretrain = os.path.join(project_dir,'trained_models/pretrain.pkl') #os.path.join(model_dir,'pretrain_models','pose_higher_hrnet_w32_512.pth') #
+    args.tab = '{}_cm{}_{}'.format(args.backbone,args.centermap_size,args.tab)
+
+    return args

--- a/src/lib/config.py
+++ b/src/lib/config.py
@@ -122,7 +122,8 @@ class ConfigContext(object):
         self.clean()
         # store all the parsed_args in a yaml file
         with open(self.yaml_filename, 'w') as f:
-            f.write(yaml.dumps(self.parsed_args.__dict__))
+            d = self.parsed_args.__dict__
+            yaml.dump(d, f)
 
     def clean(self):
         if os.path.exists(self.yaml_filename):

--- a/src/lib/config.py
+++ b/src/lib/config.py
@@ -120,7 +120,7 @@ class ConfigContext(object):
         # store all the parsed_args in a yaml file
         with open(self.yaml_filename, 'w') as f:
             f.write(yaml.dumps(parsed_args.__dict__))
-    
+
     def clean(self):
         if os.path.exists(self.yaml_filename):
             os.remove(self.yaml_filename)
@@ -129,11 +129,12 @@ class ConfigContext(object):
         # delete the yaml file
         self.clean()
 
-def get_args():
-    args = parse_args(['--tab', 'ROMP_v1']) # have to pass something or it'll try and read stdin
+def args():
+    # have to pass something or it'll try and read stdin, it should get overwritten on file load
+    parsed_args = parse_args(['--tab', 'ROMP_v1']) 
     with open(ConfigContext.yaml_filename, 'r') as f:
         argsdict = yaml.load(f)
     for k, v in argsdict:
-        args.__dict__[k] = v
-    return args
+        parsed_args.__dict__[k] = v
+    return parsed_args
 

--- a/src/lib/config.py
+++ b/src/lib/config.py
@@ -129,7 +129,7 @@ class ConfigContext(object):
         if os.path.exists(self.yaml_filename):
             os.remove(self.yaml_filename)
 
-    def __exit__(self):
+    def __exit__(self, exception_type, exception_value, traceback):
         # delete the yaml file
         self.clean()
 
@@ -137,8 +137,16 @@ def args():
     # have to pass something or it'll try and read stdin, it should get overwritten on file load
     parsed_args = parse_args(['--tab', 'ROMP_v1']) 
     with open(ConfigContext.yaml_filename, 'r') as f:
-        argsdict = yaml.load(f)
-    for k, v in argsdict:
+        argsdict = yaml.load(f, Loader=yaml.FullLoader)
+    for k, v in argsdict.items():
         parsed_args.__dict__[k] = v
     return parsed_args
 
+if __name__ == "__main__":
+    _args = parse_args()
+    with ConfigContext(_args):
+        with open(ConfigContext.yaml_filename, 'r') as f:
+            print(f.read())
+        for k, v in args().__dict__.items():
+            print(k, v)
+            assert _args.__dict__[k] == v

--- a/src/lib/config.py
+++ b/src/lib/config.py
@@ -7,13 +7,13 @@ import yaml
 import logging
 
 
-def parse_args(input_args=None):
-    code_dir = os.path.abspath(__file__).replace('config.py','')
-    project_dir = os.path.abspath(__file__).replace('/src/lib/config.py','')
-    root_dir = project_dir.replace(project_dir.split('/')[-1],'')#os.path.abspath(__file__).replace('/CenterMesh/src/config.py','')
-    model_dir = os.path.join(project_dir,'models')
-    trained_model_dir = os.path.join(project_dir,'trained_models')
+code_dir = os.path.abspath(__file__).replace('config.py','')
+project_dir = os.path.abspath(__file__).replace('/src/lib/config.py','')
+root_dir = project_dir.replace(project_dir.split('/')[-1],'')#os.path.abspath(__file__).replace('/CenterMesh/src/config.py','')
+model_dir = os.path.join(project_dir,'models')
+trained_model_dir = os.path.join(project_dir,'trained_models')
 
+def parse_args(input_args=None):
     parser = argparse.ArgumentParser(description = 'ROMP: Monocular, One-stage, Regression of Multiple 3D People')
     parser.add_argument('--tab',type = str,default = 'ROMP_v1',help = 'additional tabs')
     parser.add_argument('--configs_yml',type = str,default = 'configs/single_image.yml',help = 'setting for training') #'configs/basic_training_v6_ld.yml' 

--- a/src/lib/config.py
+++ b/src/lib/config.py
@@ -114,12 +114,15 @@ class ConfigContext(object):
     accessed anywhere.
     """
     yaml_filename = "active_context.yaml"
-    def __enter__(self, parsed_args):
+    def __init__(self, parsed_args):
+        self.parsed_args = parsed_args
+
+    def __enter__(self):
         # if a yaml is left over here, remove it
         self.clean()
         # store all the parsed_args in a yaml file
         with open(self.yaml_filename, 'w') as f:
-            f.write(yaml.dumps(parsed_args.__dict__))
+            f.write(yaml.dumps(self.parsed_args.__dict__))
 
     def clean(self):
         if os.path.exists(self.yaml_filename):

--- a/src/lib/dataset/image_base.py
+++ b/src/lib/dataset/image_base.py
@@ -31,8 +31,8 @@ class Image_base(Dataset):
         super(Image_base,self).__init__()
         self.heatmap_mapper = constants.joint_mapping(constants.SMPL_ALL_54, constants.COCO_17)
 
-        self.input_shape = [args.input_size, args.input_size]
-        self.high_resolution=args.high_resolution
+        self.input_shape = [args().input_size, args().input_size]
+        self.high_resolution=args().high_resolution
         self.vis_size = 512 if self.high_resolution else 256
         self.labels, self.images, self.file_paths = [],[],[]
 
@@ -40,7 +40,7 @@ class Image_base(Dataset):
         self.torso_ids = [constants.SMPL_ALL_54[part] for part in ['Neck', 'Neck_LSP', 'R_Shoulder', 'L_Shoulder','Pelvis', 'R_Hip', 'L_Hip']]
         self.heatmap_res = 128
         self.joint_number = len(list(constants.SMPL_ALL_54.keys()))
-        self.max_person = args.max_person
+        self.max_person = args().max_person
 
     def process_kps(self,kps,img_size,set_minus=True):
         kps = kps.astype(np.float32)
@@ -216,5 +216,5 @@ def off_set_pts(keyPoints, leftTop):
 def check_and_mkdir(dir):
     os.makedirs(dir,exist_ok=True)
 
-def denormalize_kp2ds(mat, img_size=args.input_size):
+def denormalize_kp2ds(mat, img_size=args().input_size):
     return (mat+1)/2*img_size

--- a/src/lib/dataset/internet.py
+++ b/src/lib/dataset/internet.py
@@ -42,7 +42,7 @@ class Internet(Dataset):
             imgpath = self.get_image_info(index)
             image = cv2.imread(imgpath)
 
-        input_data = img_preprocess(image, imgpath, input_size=args.input_size)
+        input_data = img_preprocess(image, imgpath, input_size=args().input_size)
 
         return input_data
 

--- a/src/lib/dataset/pw3d.py
+++ b/src/lib/dataset/pw3d.py
@@ -10,7 +10,7 @@ set_names = {'all':['train','val','test'],'test':['test'],'val':['train','val','
 class PW3D(Image_base):
     def __init__(self,train_flag = False, split='test', mode='vibe', regress_smpl=True, **kwargs):
         super(PW3D,self).__init__(train_flag)
-        self.data_folder = args.dataset_rootdir
+        self.data_folder = args().dataset_rootdir
         self.data3d_dir = os.path.join(self.data_folder,'sequenceFiles')
         self.image_dir = os.path.join(self.data_folder,'imageFiles')
         self.mode = mode
@@ -18,7 +18,7 @@ class PW3D(Image_base):
 
         logging.info('Loading 3DPW in {} mode, split {}'.format(mode,self.split))
         if mode == 'vibe':
-            self.annots_path = args.annot_dir #os.path.join(config.project_dir,'data/vibe_db')
+            self.annots_path = args().annot_dir #os.path.join(config.project_dir,'data/vibe_db')
             self.joint_mapper = constants.joint_mapping(constants.LSP_14,constants.SMPL_ALL_54)
             self.joint3d_mapper = constants.joint_mapping(constants.LSP_14,constants.SMPL_ALL_54)
             self.load_vibe_annots()

--- a/src/lib/maps_utils/centermap.py
+++ b/src/lib/maps_utils/centermap.py
@@ -7,13 +7,13 @@ from config import args
 class CenterMap(object):
     def __init__(self,style='heatmap_adaptive_scale'):
         self.style=style
-        self.size = args.centermap_size
-        self.max_person = args.max_person
-        self.shrink_scale = float(args.input_size//self.size)
+        self.size = args().centermap_size
+        self.max_person = args().max_person
+        self.shrink_scale = float(args().input_size//self.size)
         self.dims = 1
         self.sigma = 1
-        self.conf_thresh= args.centermap_conf_thresh
-        self.gk_group, self.pool_group = self.generate_kernels(args.kernel_sizes)
+        self.conf_thresh= args().centermap_conf_thresh
+        self.gk_group, self.pool_group = self.generate_kernels(args().kernel_sizes)
 
     def generate_kernels(self, kernel_size_list):
         gk_group, pool_group = {}, {}
@@ -39,7 +39,7 @@ class CenterMap(object):
         return self.parse_centermap_heatmap_adaptive_scale_batch(center_map)
 
     def parse_centermap_heatmap_adaptive_scale_batch(self, center_maps):
-        center_map_nms = nms(center_maps, pool_func=self.pool_group[args.kernel_sizes[-1]])
+        center_map_nms = nms(center_maps, pool_func=self.pool_group[args().kernel_sizes[-1]])
         b, c, h, w = center_map_nms.shape
         K = self.max_person
 

--- a/src/lib/maps_utils/result_parser.py
+++ b/src/lib/maps_utils/result_parser.py
@@ -17,7 +17,7 @@ from utils.rot_6D import rot6D_to_angular
 class ResultParser(nn.Module):
     def __init__(self):
         super(ResultParser,self).__init__()
-        self.map_size = args.centermap_size
+        self.map_size = args().centermap_size
         self.params_map_parser = SMPLWrapper()
         self.centermap_parser = CenterMap()
 
@@ -60,7 +60,7 @@ class ResultParser(nn.Module):
                 center_pred = cyxs[vpred_batch_ids==batch_id]
                 center_gt = center_pred[torch.argmin(torch.norm(center_pred.float()-center_gt[None].float().to(device),dim=-1))].long()
                 cy, cx = torch.clamp(center_gt, 0, self.map_size-1)
-                flat_ind = cy*args.centermap_size+cx
+                flat_ind = cy*args().centermap_size+cx
                 mc['batch_ids'].append(batch_id); mc['flat_inds'].append(flat_ind); mc['person_ids'].append(person_id)
         keys_list = list(mc.keys())
         for key in keys_list:
@@ -117,5 +117,5 @@ class ResultParser(nn.Module):
         return outputs,meta_data
 
 def flatten_inds(coords):
-    coords = torch.clamp(coords, 0, args.centermap_size-1)
-    return coords[:,0].long()*args.centermap_size+coords[:,1].long()
+    coords = torch.clamp(coords, 0, args().centermap_size-1)
+    return coords[:,0].long()*args().centermap_size+coords[:,1].long()

--- a/src/lib/models/base.py
+++ b/src/lib/models/base.py
@@ -15,8 +15,6 @@ if root_dir not in sys.path:
     sys.path.insert(0, root_dir)
 import config
 from config import args
-if args().model_precision=='fp16':
-    from torch.cuda.amp import autocast
 
 BN_MOMENTUM = 0.1
 default_cfg = {'mode':'val', 'calc_loss': False}
@@ -34,6 +32,7 @@ class Base(nn.Module):
 
     def train_forward(self, meta_data, **cfg):
         if args().model_precision=='fp16':
+            from torch.cuda.amp import autocast
             with autocast():
                 outputs = self.feed_forward(meta_data)
                 outputs, meta_data = self._result_parser.train_forward(outputs, meta_data, cfg)
@@ -46,6 +45,7 @@ class Base(nn.Module):
     @torch.no_grad()
     def val_forward(self, meta_data, **cfg):
         if args().model_precision=='fp16':
+            from torch.cuda.amp import autocast
             with autocast():
                 outputs = self.feed_forward(meta_data)
                 outputs, meta_data = self._result_parser.val_forward(outputs, meta_data, cfg)
@@ -64,6 +64,7 @@ class Base(nn.Module):
     @torch.no_grad()
     def pure_forward(self, meta_data, **cfg):
         if args().model_precision=='fp16':
+            from torch.cuda.amp import autocast
             with autocast():
                 outputs = self.feed_forward(meta_data)
         else:

--- a/src/lib/models/base.py
+++ b/src/lib/models/base.py
@@ -15,7 +15,7 @@ if root_dir not in sys.path:
     sys.path.insert(0, root_dir)
 import config
 from config import args
-if args.model_precision=='fp16':
+if args().model_precision=='fp16':
     from torch.cuda.amp import autocast
 
 BN_MOMENTUM = 0.1
@@ -33,7 +33,7 @@ class Base(nn.Module):
             raise NotImplementedError('forward mode is not recognized! please set proper mode (train/val)')
 
     def train_forward(self, meta_data, **cfg):
-        if args.model_precision=='fp16':
+        if args().model_precision=='fp16':
             with autocast():
                 outputs = self.feed_forward(meta_data)
                 outputs, meta_data = self._result_parser.train_forward(outputs, meta_data, cfg)
@@ -45,7 +45,7 @@ class Base(nn.Module):
 
     @torch.no_grad()
     def val_forward(self, meta_data, **cfg):
-        if args.model_precision=='fp16':
+        if args().model_precision=='fp16':
             with autocast():
                 outputs = self.feed_forward(meta_data)
                 outputs, meta_data = self._result_parser.val_forward(outputs, meta_data, cfg)
@@ -63,7 +63,7 @@ class Base(nn.Module):
 
     @torch.no_grad()
     def pure_forward(self, meta_data, **cfg):
-        if args.model_precision=='fp16':
+        if args().model_precision=='fp16':
             with autocast():
                 outputs = self.feed_forward(meta_data)
         else:

--- a/src/lib/models/build.py
+++ b/src/lib/models/build.py
@@ -13,12 +13,12 @@ Backbones = {'hrnet': HigherResolutionNet, 'resnet': ResNet_50}
 Heads = {1: ROMPv1}
 
 def build_model():
-    if args.backbone in Backbones:
-        backbone = Backbones[args.backbone]()
+    if args().backbone in Backbones:
+        backbone = Backbones[args().backbone]()
     else:
         raise "Backbone not recognized!!"
-    if args.model_version in Heads:
-        ROMP = Heads[args.model_version]
+    if args().model_version in Heads:
+        ROMP = Heads[args().model_version]
     else:
         raise "Head not recognized!!"
     model = ROMP(backbone=backbone)

--- a/src/lib/models/modelv1.py
+++ b/src/lib/models/modelv1.py
@@ -124,15 +124,17 @@ class ROMP(Base):
         return kernel_sizes, strides, paddings
 
 if __name__ == '__main__':
-    args().configs_yml = 'configs/basic_training_v1.yml'
-    args().model_version=1
-    from models.build import build_model
-    model = build_model().cuda()
-    outputs=model.feed_forward({'image':torch.rand(4,512,512,3).cuda()})
-    for key, value in outputs.items():
-        if isinstance(value,tuple):
-            print(key, value)
-        elif isinstance(value,list):
-            print(key, value)
-        else:
-            print(key, value.shape)
+    from config import args, ConfigContext, parse_args
+    with ConfigContext(parse_args()):
+        args().configs_yml = 'configs/basic_training_v1.yml'
+        args().model_version=1
+        from models.build import build_model
+        model = build_model().cuda()
+        outputs=model.feed_forward({'image':torch.rand(4,512,512,3).cuda()})
+        for key, value in outputs.items():
+            if isinstance(value,tuple):
+                print(key, value)
+            elif isinstance(value,list):
+                print(key, value)
+            else:
+                print(key, value.shape)

--- a/src/lib/models/modelv1.py
+++ b/src/lib/models/modelv1.py
@@ -43,7 +43,7 @@ class ROMP(Base):
 
     def _build_head(self):
         self.NUM_JOINTS = 17
-        self.outmap_size = args.centermap_size
+        self.outmap_size = args().centermap_size
         params_num = self._result_parser.params_map_parser.params_num
         cam_dim = 3
         self.head_cfg = {'NUM_HEADS': 1, 'NUM_CHANNELS': 64, 'NUM_BASIC_BLOCKS': 2}
@@ -124,8 +124,8 @@ class ROMP(Base):
         return kernel_sizes, strides, paddings
 
 if __name__ == '__main__':
-    args.configs_yml = 'configs/basic_training_v1.yml'
-    args.model_version=1
+    args().configs_yml = 'configs/basic_training_v1.yml'
+    args().model_version=1
     from models.build import build_model
     model = build_model().cuda()
     outputs=model.feed_forward({'image':torch.rand(4,512,512,3).cuda()})

--- a/src/lib/models/smpl.py
+++ b/src/lib/models/smpl.py
@@ -359,7 +359,7 @@ class SMPL(nn.Module):
             joints = torch.cat([joints, vertices2joints(self.J_regressor_extra9, vertices)],1)
             # use the Pelvis of most 2D image, not the original Pelvis
             root_trans = joints[:,49].unsqueeze(1)
-            if args.model_version!=1 or args.backbone!='hrnet':
+            if args().model_version!=1 or args().backbone!='hrnet':
                 joints = joints - root_trans
                 vertices =  vertices - root_trans
 

--- a/src/lib/models/smpl_wrapper.py
+++ b/src/lib/models/smpl_wrapper.py
@@ -16,12 +16,12 @@ from utils.rot_6D import rot6D_to_angular
 class SMPLWrapper(nn.Module):
     def __init__(self):
         super(SMPLWrapper,self).__init__()
-        self.smpl_model = smpl_model.create(args.smpl_model_path, J_reg_extra9_path=args.smpl_J_reg_extra_path, J_reg_h36m17_path=args.smpl_J_reg_h37m_path, \
-            batch_size=args.batch_size,model_type='smpl', gender='neutral', use_face_contour=False, ext='npz',flat_hand_mean=True, use_pca=False)
-        if '-1' not in args.gpu:
+        self.smpl_model = smpl_model.create(args().smpl_model_path, J_reg_extra9_path=args().smpl_J_reg_extra_path, J_reg_h36m17_path=args().smpl_J_reg_h37m_path, \
+            batch_size=args().batch_size,model_type='smpl', gender='neutral', use_face_contour=False, ext='npz',flat_hand_mean=True, use_pca=False)
+        if '-1' not in args().gpu:
             self.smpl_model = self.smpl_model.cuda()
         self.part_name = ['cam', 'global_orient', 'body_pose', 'betas']
-        self.part_idx = [args.cam_dim, args.rot_dim, (args.smpl_joint_num-1)*args.rot_dim, 10]
+        self.part_idx = [args().cam_dim, args().rot_dim, (args().smpl_joint_num-1)*args().rot_dim, 10]
         self.params_num = np.array(self.part_idx).sum()
 
     def forward(self, outputs, meta_data):
@@ -30,7 +30,7 @@ class SMPLWrapper(nn.Module):
             idx_list.append(idx_list[i] + idx)
             params_dict[name] = outputs['params_pred'][:, idx_list[i]: idx_list[i+1]].contiguous()
 
-        if args.Rot_type=='6D':
+        if args().Rot_type=='6D':
             params_dict['body_pose'] = rot6D_to_angular(params_dict['body_pose'])
             params_dict['global_orient'] = rot6D_to_angular(params_dict['global_orient'])
         N = params_dict['body_pose'].shape[0]

--- a/src/lib/utils/center_utils.py
+++ b/src/lib/utils/center_utils.py
@@ -18,6 +18,6 @@ def process_gt_center(center_normed):
     valid_mask = center_normed[:,:,0]>-1
     valid_inds = torch.where(valid_mask)
     valid_batch_inds, valid_person_ids = valid_inds[0], valid_inds[1]
-    center_gt = ((center_normed+1)/2*args.centermap_size).long()
+    center_gt = ((center_normed+1)/2*args().centermap_size).long()
     center_gt_valid = center_gt[valid_mask]
     return (valid_batch_inds, valid_person_ids, center_gt_valid)

--- a/src/lib/utils/demo_utils.py
+++ b/src/lib/utils/demo_utils.py
@@ -134,7 +134,7 @@ class OneEuroFilter:
 class OpenCVCapture:
     def __init__(self, video_file=None):
         if video_file is None:
-            self.cap = cv2.VideoCapture(int(args.cam_id))
+            self.cap = cv2.VideoCapture(int(args().cam_id))
         else:
             self.cap = cv2.VideoCapture(video_file)
 
@@ -162,10 +162,10 @@ class Open3d_visualizer(object):
         self.view_mat = axangle2mat([1, 0, 0], np.pi) # align different coordinate systems
         self.window_size = 1080
         
-        smpl_param_dict = pickle.load(open(os.path.join(args.smpl_model_path,'smpl','SMPL_NEUTRAL.pkl'),'rb'), encoding='latin1')
+        smpl_param_dict = pickle.load(open(os.path.join(args().smpl_model_path,'smpl','SMPL_NEUTRAL.pkl'),'rb'), encoding='latin1')
         self.faces = smpl_param_dict['f']
         self.verts_mean = smpl_param_dict['v_template']
-        self.mesh_color = np.array(constants.mesh_color_dict[args.webcam_mesh_color])/255.
+        self.mesh_color = np.array(constants.mesh_color_dict[args().webcam_mesh_color])/255.
 
         self.viewer = o3d.visualization.Visualizer()
         self.viewer.create_window(width=self.window_size+1, height=self.window_size+1, window_name='ROMP - output')
@@ -258,7 +258,7 @@ class Open3d_visualizer(object):
         self.mesh.compute_vertex_normals()
 
     def set_texture(self, mesh):
-        if args.webcam_mesh_color=='female_tex' or args.webcam_mesh_color=='male_tex':
+        if args().webcam_mesh_color=='female_tex' or args().webcam_mesh_color=='male_tex':
             print('setting texture')
             mesh.triangle_uvs = o3d.utility.Vector2dVector(self.smpl_uvmap) 
             mesh.textures = [o3d.geometry.Image(self.smpl_uv_texture)]
@@ -276,19 +276,19 @@ def frames2video(images, video_name,fps=30):
 
 class vedo_visualizer(object):
     def __init__(self):  
-        smpl_param_dict = pickle.load(open(os.path.join(args.smpl_model_path,'smpl','SMPL_NEUTRAL.pkl'),'rb'), encoding='latin1')
+        smpl_param_dict = pickle.load(open(os.path.join(args().smpl_model_path,'smpl','SMPL_NEUTRAL.pkl'),'rb'), encoding='latin1')
         self.faces = smpl_param_dict['f']
         #self.verts_mean = smpl_param_dict['v_template']
         #self.load_smpl_tex()
         #self.load_smpl_vtk()
-        if args.webcam_mesh_color == 'female_tex':
-            self.uv_map = np.load(args.smpl_uvmap)
-            self.texture_file = args.smpl_female_texture
-        elif args.webcam_mesh_color == 'male_tex':
-            self.uv_map = np.load(args.smpl_uvmap)
-            self.texture_file = args.smpl_male_texture
+        if args().webcam_mesh_color == 'female_tex':
+            self.uv_map = np.load(args().smpl_uvmap)
+            self.texture_file = args().smpl_female_texture
+        elif args().webcam_mesh_color == 'male_tex':
+            self.uv_map = np.load(args().smpl_uvmap)
+            self.texture_file = args().smpl_male_texture
         else:
-            self.mesh_color = np.array(constants.mesh_color_dict[args.webcam_mesh_color])/255.
+            self.mesh_color = np.array(constants.mesh_color_dict[args().webcam_mesh_color])/255.
 
         #self.mesh = self.create_single_mesh(self.verts_mean)
         self.mesh_smoother = OneEuroFilter(4.0, 0.0)
@@ -298,7 +298,7 @@ class vedo_visualizer(object):
     
     def load_smpl_tex(self):
         import scipy.io as sio
-        UV_info = sio.loadmat(os.path.join(args.smpl_model_path,'smpl','UV_Processed.mat'))
+        UV_info = sio.loadmat(os.path.join(args().smpl_model_path,'smpl','UV_Processed.mat'))
         self.vertex_reorder = UV_info['All_vertices'][0]-1
         self.faces = UV_info['All_Faces']-1
         self.uv_map = np.concatenate([UV_info['All_U_norm'], UV_info['All_V_norm']],1)
@@ -324,7 +324,7 @@ class vedo_visualizer(object):
     def collapse_triangles_with_large_gradient(self, mesh, threshold=4.0):
         points = mesh.points()
         new_points = np.array(points)
-        mesh_vtk = Mesh(os.path.join(args.smpl_model_path,'smpl','smpl_male.vtk'), c='w').texture(self.texture_file).lw(0.1)
+        mesh_vtk = Mesh(os.path.join(args().smpl_model_path,'smpl','smpl_male.vtk'), c='w').texture(self.texture_file).lw(0.1)
         grad = mesh_vtk.gradient("tcoords")
         ugrad, vgrad = np.split(grad, 2, axis=1)
         ugradm, vgradm = mag(ugrad), mag(vgrad)

--- a/src/lib/utils/remote_server_utils.py
+++ b/src/lib/utils/remote_server_utils.py
@@ -12,8 +12,8 @@ from config import args
 
 class Server_port_receiver(object):
     def __init__(self):
-        host = args.server_ip
-        port = args.server_port
+        host = args().server_ip
+        port = args().server_port
         self.server_sock = Listener((host, port))
         self.conn = self.server_sock.accept()
     def receive(self):

--- a/src/lib/visualization/renderer.py
+++ b/src/lib/visualization/renderer.py
@@ -138,7 +138,7 @@ class Renderer:
         return image
 
 def get_renderer(test=False,resolution = (512,512,3),part_segment=False):
-    faces = pickle.load(open(os.path.join(args.smpl_model_path,'smpl','SMPL_NEUTRAL.pkl'),'rb'), encoding='latin1')['f']
+    faces = pickle.load(open(os.path.join(args().smpl_model_path,'smpl','SMPL_NEUTRAL.pkl'),'rb'), encoding='latin1')['f']
     renderer = Renderer(faces,resolution=resolution[:2])
     
     return renderer


### PR DESCRIPTION
Running argparse on import makes it tricky to modularise the code. Added a context manager that:

- Saves command line arguments to a file
- Allows access anywhere in the library through the `args` function when this is used

This means that most of the library must be called in a `ConfigContext` environment as shown in [`src/core/test.py`](https://github.com/gngdb/ROMP/blob/master/src/core/test.py#L214-L230).

The only difference to access command line args is that wherever `args` was accessed before it must be called as a function `args()` then accessed. This involves loading the saved `active_context.yaml` so it would be more efficient to use `_args = args()` then access `_args` but in practice I don't think it affects the speed of the script. Example of new usage is [here](https://github.com/gngdb/ROMP/blob/master/src/core/base.py#L31).

Not fully tested, I've only run this in the notebook to check and my updated notebook is [here](https://colab.research.google.com/drive/1p1cqBaj_EcHmpTECxENf0q3mK_LhT70L?usp=sharing). I can't update the linked notebook in this pull request but I don't mind if you copy anything from that notebook to update the linked notebook in the repository.