### PR TITLE
fix(critical): misc bugfixes to make ROMP usable again

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,6 +41,9 @@ ROMP
 [Pytorch 1.10.0](https://pytorch.org/)  
 [Pytorch3d 0.6.1](https://github.com/facebookresearch/pytorch3d/blob/master/INSTALL.md)  
 
+**Windows only:** To build some package wheels, 'Visual Studio Build Tools' and 'Visual C++ build tools workload' are required.
+You may install them with the [Chocolatey](https://chocolatey.org) package manager: `choco install visualstudio2019buildtools visualstudio2019-workload-vctools`.
+
 Firstly, please decide whether you want to install via conda env with python 3.7 or python 3.8 or pip.  
 We recommend installing via conda so that ROMP env is clean and will not affect other repo.  
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,25 +38,29 @@ ROMP
 
 #### Set up environments
 
-[Pytorch 1.10.0](https://pytorch.org/)  
-[Pytorch3d 0.6.1](https://github.com/facebookresearch/pytorch3d/blob/master/INSTALL.md)  
+ * [Pytorch](https://pytorch.org/)  
+ * [Pytorch3d](https://github.com/facebookresearch/pytorch3d/blob/master/INSTALL.md) (optional)
 
 **Windows only:** To build some package wheels, 'Visual Studio Build Tools' and 'Visual C++ build tools workload' are required.
 You may install them with the [Chocolatey](https://chocolatey.org) package manager: `choco install visualstudio2019buildtools visualstudio2019-workload-vctools`.
 
-Firstly, please decide whether you want to install via conda env with python 3.7 or python 3.8 or pip.  
+Firstly, please decide whether you want to install via [pip](https://pip.pypa.io/en/stable) or [conda](https://docs.conda.io/en/latest/miniconda.html) env and Python 3.9, 3.8 or 3.7.  
+
 We recommend installing via conda so that ROMP env is clean and will not affect other repo.  
 
-Option 1) to install conda env with python 3.7, please run
+Option 1) to install conda env with python 3.9, please run
+1. ```
+   conda create -n ROMP python=3.9
+   conda activate ROMP
+   conda install -n ROMP pytorch=1.10 torchvision=0.11 cudatoolkit=11.3 -c pytorch  
+   ```
+   
+2. *Optional:* Install 'pytorch3d'
 
-```
-conda create -n ROMP python==3.7.6  
-conda activate ROMP  
-conda install -n ROMP pytorch==1.10.0 torchvision==0.11.1 cudatoolkit=10.2 -c pytorch  
-pip install https://github.com/Arthur151/ROMP/releases/download/v1.1/pytorch3d-0.6.1-cp37-cp37m-linux_x86_64.whl
-cd ROMP  
-pip install -r requirements.txt  
-```
+3. ```
+   cd ROMP  
+   pip install -r requirements.txt  
+   ```
 
 Option 2) to install conda env with python 3.8, please run
 ```
@@ -68,7 +72,17 @@ cd ROMP
 pip install -r requirements.txt  
 ```
 
-Option 3) To directly install via pip, you need to install CUDA 10.2 first (For Ubuntu, run`sudo apt-get install cuda-10-2`) and then install via:
+Option 3) to install conda env with python 3.7, please run
+```
+conda create -n ROMP python==3.7.6  
+conda activate ROMP  
+conda install -n ROMP pytorch==1.10.0 torchvision==0.11.1 cudatoolkit=10.2 -c pytorch  
+pip install https://github.com/Arthur151/ROMP/releases/download/v1.1/pytorch3d-0.6.1-cp37-cp37m-linux_x86_64.whl
+cd ROMP  
+pip install -r requirements.txt  
+```
+
+Option 4) To directly install via pip, you need to install CUDA 10.2 first (For Ubuntu, run`sudo apt-get install cuda-10-2`) and then install via:
 ```
 pip install pytorch==1.10.0 torchvision==0.11.1
 # if you use Python3.8, please install pytorch3d via

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==59.5.*
 opencv-python
 opencv-contrib-python
 prettytable

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,5 @@ norfair
 h5py
 imageio-ffmpeg
 pyrender
+joblib
+pandas

--- a/romp/lib/config.py
+++ b/romp/lib/config.py
@@ -10,19 +10,12 @@ import platform
 
 currentfile = os.path.abspath(__file__)
 code_dir = currentfile.replace('config.py','')
-project_dir = currentfile.replace('/romp/lib/config.py','')
-source_dir = currentfile.replace('/lib/config.py','')
-root_dir = project_dir.replace(project_dir.split('/')[-1],'')
+project_dir = currentfile.replace(os.sep + 'romp' + os.sep + 'lib' + os.sep + 'config.py','')
+source_dir = currentfile.replace(os.sep + 'lib' + os.sep + 'config.py','')
+root_dir = project_dir.replace(project_dir.split(os.sep)[-1],'')
 
 time_stamp = time.strftime('%Y-%m-%d_%H:%M:%S',time.localtime(int(round(time.time()*1000))/1000))
-yaml_timestamp = os.path.abspath(os.path.join( project_dir, "active_configs/active_context_{}.yaml".format(time_stamp).replace(":","_")))
-
-plt = platform.system()
-if plt == "Windows":
-    project_dir = currentfile.replace('\\romp\\lib\\config.py','')
-    source_dir = currentfile.replace('\\lib\\config.py','')
-    root_dir = project_dir.replace(project_dir.split('\\')[-1],'')
-    yaml_timestamp = os.path.abspath(os.path.join( source_dir + "active_configs\\active_context_{}.yaml".format(time_stamp.replace(":","_"))))
+yaml_timestamp = os.path.abspath(os.path.join(project_dir, 'active_configs' + os.sep + "active_context_{}.yaml".format(time_stamp).replace(":","_")))
 
 model_dir = os.path.join(project_dir,'model_data')
 trained_model_dir = os.path.join(project_dir,'trained_models')

--- a/romp/lib/maps_utils/centermap.py
+++ b/romp/lib/maps_utils/centermap.py
@@ -112,12 +112,12 @@ class CenterMap(object):
 
         topk_scores, topk_inds = torch.topk(center_map_nms.reshape(b, c, -1), K)
         topk_inds = topk_inds % (h * w)
-        topk_ys = (topk_inds // w).int().float()
+        topk_ys = torch.div(topk_inds, w, rounding_mode='floor').int().float()
         topk_xs = (topk_inds % w).int().float()
         # get all topk in in a batch
         topk_score, index = torch.topk(topk_scores.reshape(b, -1), K)
         # div by K because index is grouped by K(C x K shape)
-        topk_clses = (index // K).int()
+        topk_clses = torch.div(index, K, rounding_mode='floor').int()
         topk_inds = gather_feature(topk_inds.view(b, -1, 1), index).reshape(b, K)
         topk_ys = gather_feature(topk_ys.reshape(b, -1, 1), index).reshape(b, K)
         topk_xs = gather_feature(topk_xs.reshape(b, -1, 1), index).reshape(b, K)

--- a/romp/lib/maps_utils/result_parser.py
+++ b/romp/lib/maps_utils/result_parser.py
@@ -155,7 +155,7 @@ class ResultParser(nn.Module):
         if 'params_pred' not in outputs and 'params_maps' in outputs:
             outputs['params_pred'] = self.parameter_sampling(outputs['params_maps'], batch_ids, flat_inds, use_transform=True)
         if 'centers_pred' not in outputs:
-            outputs['centers_pred'] = torch.stack([flat_inds%args().centermap_size, flat_inds//args().centermap_size],1)
+            outputs['centers_pred'] = torch.stack([flat_inds%args().centermap_size, torch.div(flat_inds, args().centermap_size, rounding_mode='floor')], 1)
             outputs['centers_conf'] = self.parameter_sampling(outputs['center_map'], batch_ids, flat_inds, use_transform=True)
         
         outputs['reorganize_idx'] = meta_data['batch_ids'][batch_ids]


### PR DESCRIPTION
This merge contains different critical bugfixes to make ROMP usable again.

Some of it are general.
Others are Windows OS related.

## Tests
- [x] Windows 10 with Python 3.9.7
- [ ] Ubuntu Linux
- [ ] Mac OS

## Fixed issues
- https://github.com/vivi90/ROMP/issues/1
- https://github.com/vivi90/ROMP/issues/2
- https://github.com/vivi90/ROMP/issues/3
- https://github.com/vivi90/ROMP/issues/4
- https://github.com/vivi90/ROMP/issues/5
- https://github.com/vivi90/ROMP/issues/6

## Install
```powershell
choco install visualstudio2019buildtools visualstudio2019-workload-vctools
conda create -n ROMP python=3.9
conda activate ROMP
conda install -n ROMP pytorch=1.10 torchvision=0.11 cudatoolkit=11.3 -c pytorch
pip install -r requirements.txt
```

## Run
```powershell
python -u -m romp.predict.image --configs_yml=configs/image.yml
```

## Configuration
My `configs/image.yml`:
```yml

ARGS:
 tab: 'process_images'
 GPUS: 0

 backbone: 'hrnet' #'resnet' #
 model_precision: 'fp32' # 'fp16'
 val_batch_size: 4
 nw: 4
 model_path: trained_models/ROMP_HRNet32_V1.pkl #  'trained_models/ROMP_ResNet50_V1.pkl'
 save_visualization_on_img: True
 smpl_mesh_root_align: False
 show_mesh_stand_on_image: False
 soi_camera: 'far' # 'close'
 interactive_vis: False
 renderer: 'pyrender' # 'pyrender' 'pytorch3d' 

 # default: run on demo/images and the results would be saved at demo/images_results
 # for video demo/videos/Messi_1
 inputs: 'E:\Projekte\py\ROMP\demo\images' #'demo/videos/Messi_1'
 collect_subdirs: False # whether to collect images from the sub-folder of the input path.
 output_dir: 'E:\Projekte\py\ROMP\demo\image_results'
 save_mesh: True
 save_centermap: False
 save_dict_results: True
 mesh_cloth: 'ghostwhite'  #'LightCyan'
```