### PR TITLE
Fix video saving crash due to missing npz file

### DIFF
--- a/simple_romp/romp/utils.py
+++ b/simple_romp/romp/utils.py
@@ -90,6 +90,10 @@ def save_video_results(frame_save_paths):
     video_sequence_results = {}
     for frame_id, save_path in enumerate(frame_save_paths):
         npz_path = osp.splitext(save_path)[0]+'.npz'
+        if not osp.exists(npz_path):
+            print(f'Missing NPZ file: {npz_path}')
+            empty_results = {'track_ids': [], 'bboxes': []}
+            np.savez(npz_path, results=empty_results)
         frame_results = np.load(npz_path, allow_pickle=True)['results'][()]
         base_name = osp.basename(save_path)
         video_results[base_name] = frame_results


### PR DESCRIPTION
This PR fixes an issue where missing frame NPZ files (due to failure detection of person) would cause the video processing workflow to crash.

If NPZ file is missing, generate an empty placeholder NPZ, which allows processing to continue.